### PR TITLE
Correct spelling in Paranoia mode comments of example_base_ruleset.xml

### DIFF
--- a/example_base_ruleset.xml
+++ b/example_base_ruleset.xml
@@ -12,7 +12,7 @@
 
 <!-- Global properties -->
 <!-- Please note that not every sniff uses them and they can be overwritten by rule -->
-<!-- Paranoya mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+<!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilities. Good for assisting manual code review. -->
 <config name="ParanoiaMode" value="1"/>
 
 <!-- BadFunctions -->


### PR DESCRIPTION
Changed "Paranoya" to "Paranoia"
Changed "vulnerabilites" to "vulnerabilities"